### PR TITLE
refactor: change the way config listeners in testng

### DIFF
--- a/src/test/java/com/spotify/oauth2/tests/_BaseTest.java
+++ b/src/test/java/com/spotify/oauth2/tests/_BaseTest.java
@@ -1,9 +1,16 @@
 package com.spotify.oauth2.tests;
 
+import com.spotify.oauth2.listeners.AnnotationTransformer;
+import com.spotify.oauth2.listeners.ListenerClass;
+import com.spotify.oauth2.listeners.MethodInterceptor;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 
 import java.lang.reflect.Method;
 
+@Listeners(value = {AnnotationTransformer.class,
+		ListenerClass.class,
+		MethodInterceptor.class})
 public class _BaseTest {
 
 	/*

--- a/testng_Jenkins.xml
+++ b/testng_Jenkins.xml
@@ -3,20 +3,11 @@
 <suite name="Automation Test Suite for Spotify Playlist APIs"
 	data-provider-thread-count="3">
 
-	<listeners>
-		<listener
-			class-name="com.spotify.oauth2.listeners.AnnotationTransformer"></listener>
-		<listener
-			class-name="com.spotify.oauth2.listeners.ListenerClass"></listener>
-		<listener
-			class-name="com.spotify.oauth2.listeners.MethodInterceptor"></listener>
-	</listeners>
-
 	<!-- thread-count="2" parallel ="methods" -->
 	<!--These values are coming from Maven command (Configured in pom.xml) -->
 	<test name="Regression Tests execution for Spotify Playlist APIs">
 		<packages>
-			<package name="com.spotify.oauth2.tests"></package>
+			<package name="com.spotify.oauth2.tests"/>
 		</packages>
-	</test> <!-- Test -->
-</suite> <!-- Suite -->
+	</test>
+</suite>

--- a/testng_Local.xml
+++ b/testng_Local.xml
@@ -2,19 +2,10 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="Automation Test Suite for Spotify Playlist APIs"
 	data-provider-thread-count="3">
-
-	<listeners>
-		<listener
-			class-name="com.spotify.oauth2.listeners.AnnotationTransformer"></listener>
-		<listener
-			class-name="com.spotify.oauth2.listeners.ListenerClass"></listener>
-		<listener
-			class-name="com.spotify.oauth2.listeners.MethodInterceptor"></listener>
-	</listeners>
 	<test name="Regression Tests execution for Spotify Playlist APIs"
 		thread-count="10" parallel="methods">
 		<packages>
-			<package name="com.spotify.oauth2.tests"></package>
+			<package name="com.spotify.oauth2.tests"/>
 		</packages>
-	</test> <!-- Test -->
-</suite> <!-- Suite -->
+	</test>
+</suite>


### PR DESCRIPTION
Setting listeners in testng file has 2 disadvatages:
- Error like https://github.com/rajatt95/MasterRestAssuredFramework/issues/1
- It requires people run by testng.xml file --> kind of annoying when you need to change this file to run only one test

This pull requests changes the setting from `by file` to `by code`:
- people can run directly from IDE for each or many tests
- if we create more testng.xml files or add more listeners, just one place to change.